### PR TITLE
修复GeoUtils.isPolylineIntersectArea中的bug

### DIFF
--- a/GeoUtils/src/GeoUtils.js
+++ b/GeoUtils/src/GeoUtils.js
@@ -541,8 +541,8 @@ var BMapGLLib = (window.BMapGLLib = BMapGLLib || {});
             return false;
         }
 
-        lines = lines.getPath().map(function (point) { return { 'lng': point.lng, 'lat': point.lat } });
-        polygon = polygon.getPath().map(function (point) { return { 'lng': point.lng, lat: point.lat } });
+        lines = lines.getPath()
+        polygon = polygon.getPath()
 
         // 包含点的判断
         if (lines.length < 1 || polygon.length <= 2) {


### PR DESCRIPTION
### 修复GeoUtils.isPolylineIntersectArea方法中的bug
```js
// 之前的代码：这里将lines转为了普通对象数组，导致在下面isPointInPolygon中类型判断总是为false
// lines = lines.getPath().map(function (point) { return { 'lng': point.lng, 'lat': point.lat } });
// polygon = polygon.getPath().map(function (point) { return { 'lng': point.lng, lat: point.lat } });
// 更改后的代码
lines = lines.getPath()
polygon = polygon.getPath()

if (lines.length < 1 || polygon.length <= 2) {
    console.error('参数出错,传入值非折线和多边形')
    return false;
}
var maybeLine = [], ploygonLine = [];
for (var j = 0; j < lines.length; j++) {
// 这里调用isPointInPolygon传入的第一个参数是一个普通对象
    if (GeoUtils.isPointInPolygon(lines[j], polygon)) {
        return true;
    }
}
```
```js
 GeoUtils.isPointInPolygon = function (point, polygon) {
        //这里对point进行类型检查，因为isPolylineIntersectArea第一个参数传入的是一个普通对象，导致类型判断总是返回false
        if (
            !(point.toString() === "Point" || point.toString() === "LatLng") ||
            !(polygon instanceof BMapGL.Polygon)
        ) {
            return false;
        }
```